### PR TITLE
Change LCA to single ancestor

### DIFF
--- a/test-tool/DiffTemplate.cpp
+++ b/test-tool/DiffTemplate.cpp
@@ -134,18 +134,14 @@ std::string exprMatcher(const Expr* E) {
 }
 
 // Creates matcher code for the arguments of a callExpr.
-std::string callExprArgs(const CallExpr* CE){ 
+std::string callExprArgs(const CallExpr* CE) { 
   std::string MatchCode;
-  std::vector<const clang::Expr*> ArgVector; 
   CallExpr::const_arg_range Args = CE->arguments();
-  if(Args.begin() != Args.end()){
-    int i = 0;
-    for(const clang::Expr* Arg : Args ){
-      ArgVector.push_back(Arg);
-      MatchCode += "hasArgument(" + std::to_string(i) + ", ";
-      MatchCode += "declRefExpr()), "; // TODO: recurse here?
-      ++i;
-    }
+  size_t i = 0;
+  for (const Expr* Arg : Args) {
+    MatchCode += "hasArgument(" + std::to_string(i) + ", ";
+    MatchCode += "expr()), "; // TODO: recurse here?
+    ++i;
   }
   return MatchCode;
 }
@@ -201,10 +197,10 @@ void printMatcher(const diff::SyntaxTree& Tree,
   Builder += toMatcherName(CurrNode.getTypeLabel());
   Builder += "(";
 
-  /*const Expr* E = ASTNode.get<Expr>();
+  const Expr* E = ASTNode.get<Expr>();
   if (E) {
     Builder += exprMatcher(E);
-  }*/
+  }
 
   // TODO: ADD MORE NARROWING MATCHERS HERE
 
@@ -243,14 +239,6 @@ void cleanUpCommas(std::string& String) {
   }
 }
 
-namespace std {
-  template<> struct hash<diff::NodeId> {
-    std::size_t operator()(const diff::NodeId& p) const noexcept {
-      return std::hash<int>()(p.Id);
-    }
-  };
-}
-
 // Find root-to-node path for lowest common ancestor
 std::deque<diff::NodeId> findRootPath(const diff::SyntaxTree& Tree, 
                                       const diff::NodeId& Id) {
@@ -265,13 +253,13 @@ std::deque<diff::NodeId> findRootPath(const diff::SyntaxTree& Tree,
 }
 
 // Lowest common ancestor for multiple nodes in AST
-std::unordered_set<diff::NodeId> LCA(const diff::SyntaxTree& Tree, 
+diff::NodeId LCA(const diff::SyntaxTree& Tree, 
                                      std::vector<diff::NodeId> Ids) {
   if (Ids.empty()) {
     llvm::outs() << "No AST difference found!\n";
-    std::unordered_set<diff::NodeId> Empty;
-    return Empty;
+    return diff::NodeId(-1);
   }
+
   std::vector<std::deque<diff::NodeId>> Paths;
   llvm::outs() << "Calculating root to node paths...\n";
   for (diff::NodeId Id : Ids) {
@@ -300,18 +288,12 @@ std::unordered_set<diff::NodeId> LCA(const diff::SyntaxTree& Tree,
     diff::NodeId CurrValue = Paths[0][Idx];
     for (std::deque<diff::NodeId> Path : Paths) {
       if (Path[Idx] != CurrValue) {
-        std::unordered_set<diff::NodeId> DiffNodes;
-        for (std::deque<diff::NodeId> P : Paths) {
-          DiffNodes.insert(P[Idx]);
-        }
-        return DiffNodes;
+        return Path[Idx-1];
       } 
     }
   }
  
-  std::unordered_set<diff::NodeId> Singleton;
-  Singleton.insert(Paths[0][ShortestLength-1]);
-  return Singleton;
+  return Paths[0][ShortestLength-1];
 }
 
 // Find highest but most specific ancestor of given node
@@ -356,6 +338,7 @@ std::vector<diff::NodeId> findSourceDiff(const diff::SyntaxTree& SrcTree,
   }
 
   // Cover deletes
+  // TODO: where to do moves?
   for (diff::NodeId Src : SrcTree) {
     if (Diff.getMapped(SrcTree, Src).isInvalid()) {
       DiffNodes.push_back(Src);
@@ -404,18 +387,14 @@ int main(int argc, const char **argv) {
   llvm::outs() << "\n";
 
   llvm::outs() << "Computing LCA...\n";
-  std::unordered_set<diff::NodeId> Ancestors = LCA(SrcTree, DiffNodes);
-  if (!Ancestors.empty()) {
-    for (diff::NodeId Ancestor : Ancestors) {
-      llvm::outs() << Ancestor.Id << "\n"; 
-    }
+  diff::NodeId Ancestor = LCA(SrcTree, DiffNodes);
+  if (Ancestor.Id != -1) {
+    llvm::outs() << Ancestor.Id << "\n";
 
-    for (diff::NodeId DiffRoot : Ancestors) {
-      std::string MatcherString;
-      printMatcher(SrcTree, DiffRoot, MatcherString);
-      cleanUpCommas(MatcherString);
-      llvm::outs() << MatcherString << "\n";
-    }
+    std::string MatcherString;
+    printMatcher(SrcTree, Ancestor, MatcherString);
+    cleanUpCommas(MatcherString);
+    llvm::outs() << MatcherString << "\n";
   } 
   return 0;
 }


### PR DESCRIPTION
Removed multiple LCAs, better for examples with using declarations inside innermost namespaces.